### PR TITLE
Fix: Ignore checkboxes

### DIFF
--- a/content.js
+++ b/content.js
@@ -31,7 +31,7 @@ const actionShortcuts = {
 };
 
 document.addEventListener('keydown', (event) => {
-  const isInputField = document.activeElement.tagName === 'INPUT' || 
+  const isInputField = (document.activeElement.tagName === 'INPUT' && document.activeElement.type !== 'checkbox') || 
                        document.activeElement.tagName === 'TEXTAREA' || 
                        document.activeElement.isContentEditable;
 


### PR DESCRIPTION
Inputs in general prevent nav shortcuts from running so they don't collide with eg typing.

Checkboxes should not prevent actions or navigation shortcuts running